### PR TITLE
mesas/sas/__init__.py: added dynamic loading of dlls

### DIFF
--- a/mesas/sas/__init__.py
+++ b/mesas/sas/__init__.py
@@ -2,3 +2,12 @@
 # from mesas.sas._sas import make_lookup
 # from mesas.sas._sas_functions import create_function
 # from mesas.sas._util import transport
+import ctypes
+import platform
+from pathlib import Path
+
+
+if platform.system() == "Windows":
+    libs_dir = Path(__file__).parent.parent / ".libs"
+    for lib in libs_dir.glob("*.dll"):
+        ctypes.CDLL(str(lib))


### PR DESCRIPTION
@charman2,
During building the Fortran extension, a `.so` is generated on Linux and MacOS in the same directory as the `model.py` while on Windows a `.pyd` file is generated in the same directory but it depends on a `.dll` generated under `mesas/.libs` which is not a default place for Windows to look for libraries. This results in an error while importing `mesas.sas.solve`.

The cleanest way I could find to resolve this which doesn't involve including binaries in our package or any manual movement of files or editing of environment variables, is to dynamically load any `.dll`s existing under `mesas/.libs` on Windows.